### PR TITLE
Minor Dockerfile syntax fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/rust:1.70.0-bullseye AS build
 WORKDIR /app
 
 # Build dependencies
-COPY Cargo.toml Cargo.lock .
+COPY Cargo.toml Cargo.lock ./
 COPY graphql_endpoints/Cargo.toml graphql_endpoints/Cargo.toml
 COPY graphql_event_broker/Cargo.toml graphql_event_broker/Cargo.toml
 COPY opa_client/Cargo.toml opa_client/Cargo.toml


### PR DESCRIPTION
Older versions of docker CLI apparently don't like this syntax:

```
% docker build .
Sending build context to Docker daemon  558.6kB
Step 1/16 : FROM docker.io/library/rust:1.70.0-bullseye AS build
 ---> 26f9b1c64317
Step 2/16 : WORKDIR /app
 ---> Using cache
 ---> 31d06659a926
Step 3/16 : COPY Cargo.toml Cargo.lock .
When using COPY with more than one source file, the destination must be a directory and end with a /
```